### PR TITLE
Add viewport metatag to improve mobile visualization

### DIFF
--- a/grade/static/css/styles.css
+++ b/grade/static/css/styles.css
@@ -16,3 +16,8 @@
   margin: 0;
   padding: 0;
 }
+
+#logo-fisl {
+  max-width: 265px;
+  width: 100%;
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -2,6 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>FISL 2012 - Fórum Internacional do Software Livre</title>
   <link rel="stylesheet" href="{{ STATIC_URL }}css/jquery.mobile-1.1.0.min.css" />
   <link rel="stylesheet" href="{{ STATIC_URL }}css/styles.css" />

--- a/templates/base.html
+++ b/templates/base.html
@@ -17,7 +17,7 @@
   <div data-role="header">
     <h1>
       <a href="#home" data-rel="back" data-direction="reverse">
-        <img src="{{ STATIC_URL }}images/logo-fisl-2012.png" alt="Logo FISL 2012" border="0" />
+        <img id="logo-fisl" src="{{ STATIC_URL }}images/logo-fisl-2012.png" alt="Logo FISL 2012" border="0" />
       </a>
     </h1>
     <p><small>Barra de filtros e ordenação: <a href="#by-day">por dia</a>, <a href="#by-track">por trilha, <a href="#by-listeners">+ populares</a>, <a href="#by-friends">+ amigos</a></small></p>


### PR DESCRIPTION
The information about this tag was acquired at
http://davidbcalhoun.com/2010/viewport-metatag

The FISL logo was adjusted for not cut on mobile devices.
